### PR TITLE
feat: 실제 참여자 수 데이터로 총 인원 수 표시 업데이트

### DIFF
--- a/src/app/meeting/info/_components/MeetingDetail.tsx
+++ b/src/app/meeting/info/_components/MeetingDetail.tsx
@@ -11,7 +11,6 @@ function MeetingDetail() {
   const meetingData = useMeetingStore((state) => state.meetingData)
   const [isExpanded, setIsExpanded] = useState(false)
   const [showToggle, setShowToggle] = useState(false)
-  const [totalParticipants, setTotalParticipants] = useState(0)
   const description = meetingData?.description ?? ''
   const MAX_LENGTH = 80
 
@@ -24,12 +23,6 @@ function MeetingDetail() {
     hasNextPage,
     isFetching,
   } = useParticipants(meetingData?.meetingId ?? 0, limit)
-
-  useEffect(() => {
-    if (participantsData?.pages[0]?.data.count) {
-      setTotalParticipants(participantsData.pages[0].data.count)
-    }
-  }, [participantsData])
 
   const observer = useRef<IntersectionObserver | null>(null)
   const lastParticipantRef = useCallback(
@@ -94,7 +87,7 @@ function MeetingDetail() {
             참여자 정보
           </div>
           <div className="text-label text-point-mint">
-            총 {participantsData ? totalParticipants : '-'}명
+            총 {participantsData?.pages[0]?.data.count ?? '-'}명
           </div>
         </div>
         <hr className="h-[1px] w-full bg-gray-800 mt-3 mb-3" />

--- a/src/app/meeting/info/_components/MeetingDetail.tsx
+++ b/src/app/meeting/info/_components/MeetingDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
-import useParticipants from '@/apis/queries/participantsQueries'
+import { useParticipants } from '@/apis/queries/participantsQueries'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
 import Edit from 'public/icons/edit.svg'
@@ -11,6 +11,7 @@ function MeetingDetail() {
   const meetingData = useMeetingStore((state) => state.meetingData)
   const [isExpanded, setIsExpanded] = useState(false)
   const [showToggle, setShowToggle] = useState(false)
+  const [totalParticipants, setTotalParticipants] = useState(0)
   const description = meetingData?.description ?? ''
   const MAX_LENGTH = 80
 
@@ -23,6 +24,12 @@ function MeetingDetail() {
     hasNextPage,
     isFetching,
   } = useParticipants(meetingData?.meetingId ?? 0, limit)
+
+  useEffect(() => {
+    if (participantsData?.pages[0]?.data.count) {
+      setTotalParticipants(participantsData.pages[0].data.count)
+    }
+  }, [participantsData])
 
   const observer = useRef<IntersectionObserver | null>(null)
   const lastParticipantRef = useCallback(
@@ -86,7 +93,9 @@ function MeetingDetail() {
           <div className="text-body1-semibold text-gray-800 mr-2">
             참여자 정보
           </div>
-          <div className="text-label text-point-mint">총 20명</div>
+          <div className="text-label text-point-mint">
+            총 {participantsData ? totalParticipants : '-'}명
+          </div>
         </div>
         <hr className="h-[1px] w-full bg-gray-800 mt-3 mb-3" />
         <div>


### PR DESCRIPTION
#80 

## 변경 사항
- 기존에 모임 정보 상세 페이지에 하드코딩되어있던 멤버 총 인원 수 데이터를 실제 데이터 값으로 대체했습니다.

## 세부 사항
- participantsData 가 로드되기 전에는 '-명' 으로 표시되도록 했습니다.


