### PR TITLE
feat: 모임 정보 수정 페이지 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "tailwindCSS.experimental.classRegex": [
     ["cva\\(([^)]*)\\)", "['\"*`]([^\"'`]).*?['\"*`]"],
     ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^'])(?:'|\"|`)"]
-  ]
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,6 @@
     ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^'])(?:'|\"|`)"]
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/src/apis/apiUtils.ts
+++ b/src/apis/apiUtils.ts
@@ -56,7 +56,7 @@ const refreshToken = async () => {
 
 export const apiCall = async (
   endpoint: string,
-  method: 'GET' | 'POST' | 'DELETE' = 'GET',
+  method: 'GET' | 'POST' | 'DELETE' | 'PATCH' = 'GET',
   body?: object,
 ) => {
   const url = `/api/v1${endpoint.startsWith('/') ? '' : '/'}${endpoint}`

--- a/src/apis/queries/meetingQueries.ts
+++ b/src/apis/queries/meetingQueries.ts
@@ -18,6 +18,12 @@ type MeetingPasswordResponse = ApiResponse<{
   password: string
   leaderAuthKey?: string
 }>
+type ModifyMeetingResponse = ApiResponse<{
+  meetingId: number
+  name: string
+  description: string
+  symbolColor: string
+}>
 
 export const useCheckNickname = (
   meetingId: number,
@@ -136,5 +142,36 @@ export const useGetMeetingPassword = (
     queryFn: () => apiCall(`/meetings/${meetingId}/password`),
     enabled: !!meetingId,
     retry: false,
+    ...options,
+  })
+
+export const useModifyMeeting = (
+  options?: UseMutationOptions<
+    ModifyMeetingResponse,
+    ApiError,
+    {
+      meetingId: number
+      name: string
+      description: string
+      symbolColor: string
+    }
+  >,
+) =>
+  useMutation<
+    ModifyMeetingResponse,
+    ApiError,
+    {
+      meetingId: number
+      name: string
+      description: string
+      symbolColor: string
+    }
+  >({
+    mutationFn: ({ meetingId, name, description, symbolColor }) =>
+      apiCall(`/meetings/${meetingId}`, 'PATCH', {
+        name,
+        description,
+        symbolColor,
+      }),
     ...options,
   })

--- a/src/app/entry-meeting/_components/MeetingInfo.tsx
+++ b/src/app/entry-meeting/_components/MeetingInfo.tsx
@@ -24,8 +24,6 @@ function MeetingInfo({
   const meetingData = useMeetingStore((state) => state.meetingData)
   const setMeetingData = useMeetingStore((state) => state.setMeetingData)
 
-  console.log('meetingData:', meetingData)
-
   const { data, isLoading, isSuccess } = useCheckMeetingLink(meetingCode || '')
 
   useEffect(() => {

--- a/src/app/manage-meeting/page.tsx
+++ b/src/app/manage-meeting/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import Image from 'next/image'
@@ -12,8 +12,11 @@ import ColorPicker from '@/components/ColorPicker'
 import { TextInput } from '@/components/Inputs/TextInput'
 import { TextareaInput } from '@/components/Inputs/TextareaInput'
 import Popup from '@/components/Popup'
+import { ToastContainer } from '@/components/Toast'
 import COLORS from '@/constant/color'
 import useMeetingStore from '@/stores/useMeetingStore'
+import useToastStore from '@/stores/useToastStore'
+import getUserErrorMessage from '@/utils/errorMessages'
 import Back from 'public/icons/back.svg'
 
 type ColorType = (typeof COLORS)[number]
@@ -34,7 +37,8 @@ type MeetingFormData = z.infer<typeof meetingSchema>
 
 function ManageMeeting() {
   const router = useRouter()
-  const { meetingData, setMeetingUpdated } = useMeetingStore()
+  const { meetingData } = useMeetingStore()
+  const { setToast, showToast, message } = useToastStore()
 
   const defaultSymbolColor: ColorType = COLORS.includes(
     meetingData?.symbolColor as ColorType,
@@ -57,15 +61,24 @@ function ManageMeeting() {
     mode: 'onChange',
   })
 
-  const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
   const [isPopupOpen, setIsPopupOpen] = useState(false)
+
+  useEffect(() => {
+    if (message) {
+      showToast()
+    }
+  }, [message, showToast])
 
   const modifyMeeting = useModifyMeeting({
     onSuccess: () => {
-      setMeetingUpdated(true)
+      setToast('모임정보 변경 완료되었어요!', {
+        position: 'bottom',
+      })
+      showToast()
       router.back()
     },
     onError: (error) => {
+<<<<<<< HEAD
       if (error.error?.message) {
         setApiErrorMessage(error.error.message)
       } else {
@@ -74,6 +87,12 @@ function ManageMeeting() {
         )
       }
       console.log(apiErrorMessage)
+=======
+      const errorMessage = getUserErrorMessage(error)
+      setToast(errorMessage, { type: 'warning' })
+      showToast()
+      console.error('API Error:', error)
+>>>>>>> 18a6179 (feat: 모임 수정 오류 메세지 토스트로 렌더링하도록 구현)
     },
   })
 
@@ -172,6 +191,7 @@ function ManageMeeting() {
           </span>
         }
       />
+      <ToastContainer />
     </div>
   )
 }

--- a/src/app/manage-meeting/page.tsx
+++ b/src/app/manage-meeting/page.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+import { useModifyMeeting } from '@/apis/queries/meetingQueries'
+import { Button } from '@/components/Button'
+import ColorPicker from '@/components/ColorPicker'
+import { TextInput } from '@/components/Inputs/TextInput'
+import { TextareaInput } from '@/components/Inputs/TextareaInput'
+import Popup from '@/components/Popup'
+import COLORS from '@/constant/color'
+import useMeetingStore from '@/stores/useMeetingStore'
+import Back from 'public/icons/back.svg'
+
+type ColorType = (typeof COLORS)[number]
+
+const meetingSchema = z.object({
+  meetingName: z
+    .string()
+    .min(1, '모임 이름을 입력해주세요')
+    .max(20, '최대 20자까지 입력이 가능해요'),
+  meetingDescription: z
+    .string()
+    .nonempty('모임 소개을 입력해주세요')
+    .max(150, '최대 150자까지 입력이 가능해요'),
+  meetingSymbolColor: z.enum(COLORS),
+})
+
+type MeetingFormData = z.infer<typeof meetingSchema>
+
+function ManageMeeting() {
+  const router = useRouter()
+  const { meetingData, setMeetingUpdated } = useMeetingStore()
+
+  const defaultSymbolColor: ColorType = COLORS.includes(
+    meetingData?.symbolColor as ColorType,
+  )
+    ? (meetingData?.symbolColor as ColorType)
+    : COLORS[0]
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isDirty },
+    setValue,
+  } = useForm<z.infer<typeof meetingSchema>>({
+    defaultValues: {
+      meetingName: meetingData?.name,
+      meetingDescription: meetingData?.description,
+      meetingSymbolColor: defaultSymbolColor,
+    },
+    resolver: zodResolver(meetingSchema),
+    mode: 'onChange',
+  })
+
+  const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
+  const [isPopupOpen, setIsPopupOpen] = useState(false)
+
+  const modifyMeeting = useModifyMeeting({
+    onSuccess: () => {
+      setMeetingUpdated(true)
+      router.back()
+    },
+    onError: (error) => {
+      if (error.error?.message) {
+        setApiErrorMessage(error.error.message)
+      } else {
+        setApiErrorMessage(
+          '모임 정보 수정 중 오류가 발생했습니다. 다시 시도해주세요.',
+        )
+      }
+    },
+  })
+
+  const onSubmit = (data: MeetingFormData) => {
+    modifyMeeting.mutate({
+      meetingId: meetingData?.meetingId ?? 0,
+      name: data.meetingName,
+      description: data.meetingDescription,
+      symbolColor: data.meetingSymbolColor,
+    })
+  }
+
+  const handleBack = () => {
+    if (isDirty) {
+      setIsPopupOpen(true)
+    } else {
+      router.back()
+    }
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen w-full p-4">
+      <div className="flex items-center justify-center relative h-[50px]">
+        <div className="absolute left-0">
+          <Image src={Back} alt="back" onClick={handleBack} />
+        </div>
+        <div className="text-center text-body1-bold text-gray-900">
+          모임 정보
+        </div>
+      </div>
+      <div className="text-gray-900 font-bold text-[22px] mt-9">
+        모임 정보를 수정할 수 있어요
+      </div>
+      <div className="text-gray-700 font-normal text-sm mt-2 mb-8">
+        변경한 모임 정보는 모든 참여원에게 반영돼요
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col flex-grow"
+      >
+        <TextInput
+          name="meetingName"
+          label="모임 이름"
+          control={control}
+          placeholder="모임 이름 입력"
+          error={errors.meetingName?.message}
+          maxLength={20}
+          showCharCount
+        />
+
+        <TextareaInput
+          name="meetingDescription"
+          label="모임 소개"
+          control={control}
+          placeholder="모임 소개 입력"
+          error={errors.meetingDescription?.message}
+          maxLength={150}
+          showCharCount
+        />
+
+        <Controller
+          name="meetingSymbolColor"
+          control={control}
+          render={({ field }) => (
+            <ColorPicker
+              label="모임 테마"
+              onColorSelect={(color: ColorType) => {
+                field.onChange(color)
+                setValue('meetingSymbolColor', color, { shouldDirty: true })
+              }}
+              selectedColor={field.value}
+            />
+          )}
+        />
+
+        <div className="flex-grow" />
+
+        <Button
+          type="submit"
+          variant="primary"
+          className="mt-auto mb-5 w-full text-white"
+          disabled={!isDirty || Object.keys(errors).length > 0}
+        >
+          변경사항 저장하기
+        </Button>
+      </form>
+      <Popup
+        isOpen={isPopupOpen}
+        onCancel={() => setIsPopupOpen(false)}
+        onConfirm={() => router.back()}
+        title={
+          <span>
+            지금 나가면
+            <br />
+            변경된 정보가 모두 사라져요 :(
+          </span>
+        }
+      />
+    </div>
+  )
+}
+
+export default ManageMeeting

--- a/src/app/manage-meeting/page.tsx
+++ b/src/app/manage-meeting/page.tsx
@@ -78,21 +78,10 @@ function ManageMeeting() {
       router.back()
     },
     onError: (error) => {
-<<<<<<< HEAD
-      if (error.error?.message) {
-        setApiErrorMessage(error.error.message)
-      } else {
-        setApiErrorMessage(
-          '모임 정보 수정 중 오류가 발생했습니다. 다시 시도해주세요.',
-        )
-      }
-      console.log(apiErrorMessage)
-=======
       const errorMessage = getUserErrorMessage(error)
       setToast(errorMessage, { type: 'warning' })
       showToast()
       console.error('API Error:', error)
->>>>>>> 18a6179 (feat: 모임 수정 오류 메세지 토스트로 렌더링하도록 구현)
     },
   })
 

--- a/src/app/manage-meeting/page.tsx
+++ b/src/app/manage-meeting/page.tsx
@@ -13,13 +13,11 @@ import { TextInput } from '@/components/Inputs/TextInput'
 import { TextareaInput } from '@/components/Inputs/TextareaInput'
 import Popup from '@/components/Popup'
 import { ToastContainer } from '@/components/Toast'
-import COLORS from '@/constant/color'
+import COLORS, { ColorType } from '@/constant/color'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useToastStore from '@/stores/useToastStore'
 import getUserErrorMessage from '@/utils/errorMessages'
 import Back from 'public/icons/back.svg'
-
-type ColorType = (typeof COLORS)[number]
 
 const meetingSchema = z.object({
   meetingName: z
@@ -40,11 +38,8 @@ function ManageMeeting() {
   const { meetingData } = useMeetingStore()
   const { setToast, showToast, message } = useToastStore()
 
-  const defaultSymbolColor: ColorType = COLORS.includes(
-    meetingData?.symbolColor as ColorType,
-  )
-    ? (meetingData?.symbolColor as ColorType)
-    : COLORS[0]
+  const defaultSymbolColor: ColorType =
+    COLORS.find((color) => color === meetingData?.symbolColor) || COLORS[0]
 
   const {
     control,

--- a/src/app/manage-meeting/page.tsx
+++ b/src/app/manage-meeting/page.tsx
@@ -73,6 +73,7 @@ function ManageMeeting() {
           '모임 정보 수정 중 오류가 발생했습니다. 다시 시도해주세요.',
         )
       }
+      console.log(apiErrorMessage)
     },
   })
 

--- a/src/app/meeting/info/_components/MeetingDetail.tsx
+++ b/src/app/meeting/info/_components/MeetingDetail.tsx
@@ -15,8 +15,6 @@ function MeetingDetail() {
   const description = meetingData?.description ?? ''
   const MAX_LENGTH = 80
 
-  console.log('meetingData:', meetingData)
-
   const limit = 10
   const {
     data: participantsData,

--- a/src/app/meeting/info/_components/MeetingDetail.tsx
+++ b/src/app/meeting/info/_components/MeetingDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useParticipants } from '@/apis/queries/participantsQueries'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
@@ -48,7 +49,11 @@ function MeetingDetail() {
       <div className="flex flex-col px-5 py-4">
         <div className="flex justify-between items-center">
           <div className=" text-body1-semibold">우리는 이런 모임이에요!</div>
-          {role === 'LEADER' && <Image src={Edit} alt="edit" />}
+          {role === 'LEADER' && (
+            <Link href="/manage-meeting">
+              <Image src={Edit} alt="edit" />
+            </Link>
+          )}
         </div>
         <hr className="h-[1px] w-full bg-gray-800 mt-3 mb-3" />
         <div>{}</div>

--- a/src/app/meeting/info/page.tsx
+++ b/src/app/meeting/info/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useCheckMeetingId } from '@/apis/queries/meetingQueries'
-import Toast from '@/components/Toast'
+import { ToastContainer } from '@/components/Toast'
 import useMeetingStore from '@/stores/useMeetingStore'
+import useToastStore from '@/stores/useToastStore'
 import Back from 'public/icons/back.svg'
 import Logo from 'public/logo.svg'
 import MeetingDetail from './_components/MeetingDetail'
@@ -14,9 +15,8 @@ import MeetingRaising from './_components/MeetingRaising'
 function MeetingInfo() {
   const router = useRouter()
   const [isMenuDetail, setIsMenuDetail] = useState(true)
-  const { meetingData, setMeetingData, meetingUpdated, setMeetingUpdated } =
-    useMeetingStore()
-  const [showToast, setShowToast] = useState(false)
+  const { meetingData, setMeetingData } = useMeetingStore()
+  const { message, showToast } = useToastStore()
 
   const { data, isLoading, error } = useCheckMeetingId(
     meetingData?.meetingId ?? 0,
@@ -34,11 +34,10 @@ function MeetingInfo() {
   }, [data, setMeetingData])
 
   useEffect(() => {
-    if (meetingUpdated) {
-      setShowToast(true)
-      setMeetingUpdated(false)
+    if (message) {
+      showToast()
     }
-  }, [meetingUpdated, setMeetingUpdated])
+  }, [message, showToast])
 
   if (isLoading) {
     return <div>Loading...</div>
@@ -48,7 +47,6 @@ function MeetingInfo() {
     return <div>Error: {error.error?.message}</div>
   }
 
-  console.log(meetingData)
   return (
     <div className="flex flex-col h-screen w-full">
       <div className="flex-none">
@@ -98,15 +96,7 @@ function MeetingInfo() {
       <div className="flex-grow overflow-y-auto">
         {isMenuDetail ? <MeetingDetail /> : <MeetingRaising />}
       </div>
-      {showToast && (
-        <Toast
-          duration={3000}
-          message="모임정보 변경 완료되었어요!"
-          position="bottom"
-          type="default"
-          onClose={() => setShowToast(false)}
-        />
-      )}
+      <ToastContainer />
     </div>
   )
 }

--- a/src/components/ColorPicker/index.stories.tsx
+++ b/src/components/ColorPicker/index.stories.tsx
@@ -17,3 +17,10 @@ export const Default: Story = {
     selectedColor: null,
   },
 }
+
+export const WithLabel: Story = {
+  args: {
+    label: '모임 테마',
+    selectedColor: null,
+  },
+}

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -4,24 +4,32 @@ import COLORS from '@/constant/color'
 type ColorType = (typeof COLORS)[number]
 
 interface ColorPickerProps {
+  label?: string
   selectedColor: ColorType | null
   onColorSelect: (color: ColorType) => void
 }
 
-const ColorPicker = ({ selectedColor, onColorSelect }: ColorPickerProps) => (
-  <div className="grid grid-cols-4 gap-[18px] my-10 place-items-center">
-    {COLORS.map((color) => (
-      <button
-        key={color}
-        type="button"
-        className={`w-12 h-[48px] rounded-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black ${
-          selectedColor === color ? 'ring-2 ring-offset-2 ring-black' : ''
-        }`}
-        style={{ backgroundColor: color }}
-        onClick={() => onColorSelect(color)}
-        aria-label={`Select ${color} color`}
-      />
-    ))}
+const ColorPicker = ({
+  label,
+  selectedColor,
+  onColorSelect,
+}: ColorPickerProps) => (
+  <div>
+    <label className="block text-gray-600 text-sm mb-4">{label}</label>
+    <div className="grid grid-cols-4 gap-[18px] place-items-center">
+      {COLORS.map((color) => (
+        <button
+          key={color}
+          type="button"
+          className={`w-12 h-[48px] rounded-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black ${
+            selectedColor === color ? 'ring-2 ring-offset-2 ring-black' : ''
+          }`}
+          style={{ backgroundColor: color }}
+          onClick={() => onColorSelect(color)}
+          aria-label={`Select ${color} color`}
+        />
+      ))}
+    </div>
   </div>
 )
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -65,7 +65,7 @@ function Toast({
 
   if (!shouldRender) return null
 
-  const positionClass = position === 'top' ? 'top-0' : 'bottom-0'
+  const positionClass = position === 'top' ? 'top-5' : 'bottom-2'
   const visibilityClass = isVisible ? 'opacity-100' : 'opacity-0'
   const transformClass = isVisible
     ? 'translate-y-0'

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import Image from 'next/image'
+import useToastStore from '@/stores/useToastStore'
 import AlertInfo from '../../../public/icons/alert-circle.svg'
 
 type ToastType = 'default' | 'info' | 'warning' | 'success'
@@ -103,6 +104,23 @@ function Toast({
         )}
       </div>
     </div>
+  )
+}
+
+export function ToastContainer() {
+  const { message, options, isVisible, hideToast } = useToastStore()
+
+  if (!isVisible || !message) return null
+
+  return (
+    <Toast
+      message={message}
+      type={options.type}
+      position={options.position}
+      duration={options.duration}
+      onClose={hideToast}
+      link={options.link}
+    />
   )
 }
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -79,7 +79,7 @@ function Toast({
       style={{ transitionProperty: 'opacity, transform' }}
     >
       <div
-        className={`flex items-center px-[18px] py-[14px] rounded-[14px] ${getTypeStyles()}`}
+        className={`flex items-center px-[18px] py-[14px] rounded-[14px] ${getTypeStyles()} whitespace-nowrap`}
       >
         {type === 'info' && (
           <Image

--- a/src/constant/color.ts
+++ b/src/constant/color.ts
@@ -9,4 +9,6 @@ const COLORS = [
   '#5FEAFF',
 ] as const
 
+export type ColorType = (typeof COLORS)[number]
+
 export default COLORS

--- a/src/stores/useMeetingStore.ts
+++ b/src/stores/useMeetingStore.ts
@@ -20,12 +20,14 @@ export interface MeetingData {
 interface MeetingState {
   meetingData: MeetingData | null
   photos: Photo[]
+  meetingUpdated: boolean
 }
 
 interface MeetingActions {
   setMeetingData: (meetingData: MeetingData | null) => void
   setMeetingId: (meetingId: number) => void
   setPhotos: (photos: Photo[]) => void
+  setMeetingUpdated: (meetingUpdated: boolean) => void
 }
 
 interface MeetingStore extends MeetingState, MeetingActions {}
@@ -35,6 +37,7 @@ const useMeetingStore = create(
     (set) => ({
       meetingData: null,
       photos: [],
+      meetingUpdated: false,
       setMeetingData: (meetingData) => set({ meetingData }),
       setMeetingId: (meetingId) =>
         set((state) => ({
@@ -43,6 +46,7 @@ const useMeetingStore = create(
             : null,
         })),
       setPhotos: (photos) => set({ photos }),
+      setMeetingUpdated: (meetingUpdated) => set({ meetingUpdated }),
     }),
     {
       name: 'meeting-storage',

--- a/src/stores/useMeetingStore.ts
+++ b/src/stores/useMeetingStore.ts
@@ -20,14 +20,12 @@ export interface MeetingData {
 interface MeetingState {
   meetingData: MeetingData | null
   photos: Photo[]
-  meetingUpdated: boolean
 }
 
 interface MeetingActions {
   setMeetingData: (meetingData: MeetingData | null) => void
   setMeetingId: (meetingId: number) => void
   setPhotos: (photos: Photo[]) => void
-  setMeetingUpdated: (meetingUpdated: boolean) => void
 }
 
 interface MeetingStore extends MeetingState, MeetingActions {}
@@ -37,7 +35,6 @@ const useMeetingStore = create(
     (set) => ({
       meetingData: null,
       photos: [],
-      meetingUpdated: false,
       setMeetingData: (meetingData) => set({ meetingData }),
       setMeetingId: (meetingId) =>
         set((state) => ({
@@ -46,7 +43,6 @@ const useMeetingStore = create(
             : null,
         })),
       setPhotos: (photos) => set({ photos }),
-      setMeetingUpdated: (meetingUpdated) => set({ meetingUpdated }),
     }),
     {
       name: 'meeting-storage',

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+
+type ToastType = 'default' | 'info' | 'warning' | 'success'
+type ToastPosition = 'top' | 'bottom'
+
+interface ToastOptions {
+  type?: ToastType
+  position?: ToastPosition
+  duration?: number
+  link?: string
+}
+
+interface ToastState {
+  message: string | null
+  options: ToastOptions
+  isVisible: boolean
+  setToast: (message: string, options?: ToastOptions) => void
+  showToast: () => void
+  hideToast: () => void
+}
+
+const useToastStore = create<ToastState>((set, get) => ({
+  message: null,
+  options: {
+    type: 'default',
+    position: 'top',
+    duration: 3000,
+  },
+  isVisible: false,
+  setToast: (message, options = {}) =>
+    set({
+      message,
+      options: { ...get().options, ...options },
+      isVisible: false,
+    }),
+  showToast: () => set({ isVisible: true }),
+  hideToast: () => set({ isVisible: false, message: null }),
+}))
+
+export default useToastStore

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,0 +1,21 @@
+function getUserErrorMessage(error: any): string {
+  if (error.status === 400) {
+    return '올바르지 않은 정보입니다.'
+  }
+  if (error.status === 401) {
+    return '다시 로그인해주세요.'
+  }
+  if (error.status === 403) {
+    return '권한이 없습니다.'
+  }
+  if (error.status === 404) {
+    return '정보를 찾을 수 없습니다.'
+  }
+  if (error.status === 500) {
+    return '서버 오류. 다시 시도해주세요.'
+  }
+
+  return '오류 발생. 다시 시도해주세요.'
+}
+
+export default getUserErrorMessage


### PR DESCRIPTION
#93 

## 변경사항
- 관리자의 모임 정보 수정 페이지를 구현하였습니다. 모임 이름, 모임 설명, 모임 테마를 수정할 수 있습니다.

## 세부사항
- VSCode 설정에 저장 시 ESLint 자동 수정이 되도록 settings.json 에 옵션을 추가했습니다.
- ColorPicker 컴포넌트에 label 속성 추가했습니다. 필수가 아닌 옵션 값입니다.
- 토스트 메세지 위치를 조정했습니다. (top 의 경우 위에서 20px, bottom 의 경우 아래에서 10px)
- 수정 사항이 있음에도(isDirty) 저장하지 않고 뒤로가기를 누르면 팝업창을 렌더링하도록 구현했습니다.

## 참고사항
- 토스트 메시지 렌더링 여부를 결정하기 위해 '모임 정보 상태' 업데이트 여부를 나타내는 전역 상태(meetingUpdated)를 추가하여 관리하고 있습니다. 이 접근 방식 관련해서 다른 제안이 있으시다면 공유부탁드립니다!