### PR TITLE
feat: 모임 재입장 로직 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,6 @@
         "optionalDependencies": false
       }
     ],
-
     "jsx-a11y/media-has-caption": "off",
     "no-nested-ternary": "off",
     "no-console": "off",
@@ -46,6 +45,7 @@
     "react/require-default-props": "off",
     "react/jsx-props-no-spreading": "off",
     "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/no-use-before-define": "off",
     "import/order": [
       "error",
       {

--- a/src/apis/PasswordPopup.tsx
+++ b/src/apis/PasswordPopup.tsx
@@ -22,7 +22,7 @@ const passwordSchema = z.object({
 type PasswordFormData = z.infer<typeof passwordSchema>
 
 function PasswordPopup() {
-  const { isOpen, meetingId, onConfirm, onClose, closePopup } =
+  const { isOpen, meetingId, onConfirm, closePopup, closePopupAndRedirect } =
     usePasswordPopupStore()
   const [isPasswordValid, setIsPasswordValid] = useState(false)
   const [isReentering, setIsReentering] = useState(false)
@@ -98,13 +98,6 @@ function PasswordPopup() {
     }
   }, [isPasswordValid, meetingId, passwordValue, onConfirm, closePopup])
 
-  const handleClose = useCallback(() => {
-    if (onClose) {
-      onClose()
-    }
-    closePopup()
-  }, [onClose, closePopup])
-
   const errorMessage =
     errors.password?.message ||
     (validatePassword.isError && debouncedPassword === lastCheckedPassword
@@ -116,7 +109,7 @@ function PasswordPopup() {
       isOpen={isOpen}
       cancelText=""
       confirmText={isReentering ? '재입장 중...' : '입장하기'}
-      onClose={handleClose}
+      onClose={closePopupAndRedirect}
       onConfirm={handleConfirm}
       title="다시 오셨네요!"
       hasCloseButton

--- a/src/apis/PasswordPopup.tsx
+++ b/src/apis/PasswordPopup.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { reenterMeeting } from '@/apis/apiUtils'
+import { TextInput } from '@/components/Inputs/TextInput/index'
+import useDebounce from '@/hooks/useDebounce'
+import { usePasswordPopupStore } from '@/stores/usePasswordPopupStore'
+import Popup from '../components/Popup/index'
+import { useValidatePassword } from './queries/meetingQueries'
+
+const passwordSchema = z.object({
+  password: z
+    .string()
+    .min(1, '암호를 입력해주세요.')
+    .min(4, '암호는 최소 4자 이상이어야 해요. :(')
+    .max(20, '비밀번호는 최대 20자까지 입력 가능해요. :('),
+})
+
+type PasswordFormData = z.infer<typeof passwordSchema>
+
+function PasswordPopup() {
+  const { isOpen, meetingId, onConfirm, onClose, closePopup } =
+    usePasswordPopupStore()
+  const [isPasswordValid, setIsPasswordValid] = useState(false)
+  const [isReentering, setIsReentering] = useState(false)
+  const [lastCheckedPassword, setLastCheckedPassword] = useState('')
+
+  const {
+    control,
+    watch,
+    formState: { errors },
+    reset,
+  } = useForm<PasswordFormData>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: {
+      password: '',
+    },
+    mode: 'onChange',
+  })
+
+  const passwordValue = watch('password')
+  const debouncedPassword = useDebounce(passwordValue, 500)
+
+  const validatePassword = useValidatePassword({
+    onSuccess: () => {
+      setIsPasswordValid(true)
+      setLastCheckedPassword(debouncedPassword)
+    },
+    onError: () => {
+      setIsPasswordValid(false)
+      setLastCheckedPassword(debouncedPassword)
+    },
+  })
+
+  useEffect(() => {
+    if (
+      debouncedPassword &&
+      debouncedPassword.length >= 4 &&
+      meetingId &&
+      debouncedPassword !== lastCheckedPassword
+    ) {
+      validatePassword.mutate({ meetingId, password: debouncedPassword })
+    } else if (debouncedPassword !== lastCheckedPassword) {
+      setIsPasswordValid(false)
+    }
+  }, [debouncedPassword, meetingId, lastCheckedPassword, validatePassword])
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset()
+      setIsPasswordValid(false)
+      setLastCheckedPassword('')
+    }
+  }, [isOpen, reset])
+
+  const handleConfirm = useCallback(async () => {
+    if (isPasswordValid && meetingId) {
+      setIsReentering(true)
+      try {
+        const success = await reenterMeeting(meetingId, passwordValue)
+        if (success) {
+          if (onConfirm) {
+            onConfirm(passwordValue)
+          }
+          closePopup()
+        } else {
+          throw new Error('재입장 실패')
+        }
+      } catch (error) {
+        console.error('Error during re-entry:', error)
+        alert('모임 재입장에 실패했습니다. 다시 시도해주세요.')
+      } finally {
+        setIsReentering(false)
+      }
+    }
+  }, [isPasswordValid, meetingId, passwordValue, onConfirm, closePopup])
+
+  const handleClose = useCallback(() => {
+    if (onClose) {
+      onClose()
+    }
+    closePopup()
+  }, [onClose, closePopup])
+
+  const errorMessage =
+    errors.password?.message ||
+    (validatePassword.isError && debouncedPassword === lastCheckedPassword
+      ? '틀린 암호입니다.'
+      : null)
+
+  return (
+    <Popup
+      isOpen={isOpen}
+      cancelText=""
+      confirmText={isReentering ? '재입장 중...' : '입장하기'}
+      onClose={handleClose}
+      onConfirm={handleConfirm}
+      title="다시 오셨네요!"
+      hasCloseButton
+      confirmDisabled={!isPasswordValid || isReentering}
+    >
+      <TextInput
+        name="password"
+        control={control}
+        type="password"
+        placeholder="암호를 입력해주세요"
+        success={isPasswordValid && debouncedPassword === lastCheckedPassword}
+        successMessage="비밀번호 입력 완료!"
+        error={errorMessage}
+        checking={validatePassword.isPending}
+      />
+    </Popup>
+  )
+}
+
+export default PasswordPopup

--- a/src/apis/apiUtils.ts
+++ b/src/apis/apiUtils.ts
@@ -50,12 +50,7 @@ const handleExpiredToken = () => {
     }
   }
 
-  const onClose = () => {
-    usePasswordPopupStore.getState().closePopup()
-    window.location.href = '/'
-  }
-
-  usePasswordPopupStore.getState().openPopup(meetingId, onConfirm, onClose)
+  usePasswordPopupStore.getState().openPopup(meetingId, onConfirm)
 }
 
 const refreshToken = async (): Promise<void> => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next'
 import '../styles/globals.css'
+import dynamic from 'next/dynamic'
 import Providers from './providers'
+
+const PasswordPopup = dynamic(() => import('@/apis/PasswordPopup'), {
+  ssr: false,
+  loading: () => <div>Loading...</div>,
+})
 
 export const metadata: Metadata = {
   title: 'Snappy',
@@ -22,7 +28,10 @@ export default function RootLayout({
       <body className="min-h-screen bg-white">
         <div className="flex justify-center">
           <div className="w-full max-w-md">
-            <Providers>{children}</Providers>
+            <Providers>
+              {children}
+              <PasswordPopup />
+            </Providers>
           </div>
         </div>
       </body>

--- a/src/components/Popup/index.tsx
+++ b/src/components/Popup/index.tsx
@@ -3,14 +3,16 @@ import CloseSvg from 'public/icons/CloseSvg'
 
 export interface PopupProps {
   title: React.ReactNode
-  onConfirm: () => void
-  onCancel: () => void
+  onConfirm?: () => void
+  onCancel?: () => void
   onClose?: () => void
   confirmText?: string
   cancelText?: string
   isOpen: boolean
   hasCloseButton?: boolean
   closeColor?: string
+  children?: React.ReactNode
+  confirmDisabled?: boolean
 }
 
 function Popup({
@@ -23,6 +25,8 @@ function Popup({
   isOpen,
   hasCloseButton = false,
   closeColor = '#4E5256',
+  confirmDisabled = false,
+  children,
 }: PopupProps) {
   if (!isOpen) return null
 
@@ -43,6 +47,7 @@ function Popup({
           <p className="text-center text-lg text-gray-700 font-medium mb-6">
             {title}
           </p>
+          {children}
           <div
             className={`flex ${cancelText !== '' && confirmText !== '' && 'space-x-2'} `}
           >
@@ -56,6 +61,7 @@ function Popup({
                 variant="primary"
                 fullWidth
                 onClick={onConfirm}
+                disabled={confirmDisabled}
                 className="text-white"
               >
                 {confirmText}

--- a/src/stores/usePasswordPopupStore.ts
+++ b/src/stores/usePasswordPopupStore.ts
@@ -4,24 +4,22 @@ type PasswordPopupStore = {
   isOpen: boolean
   meetingId: number | null
   onConfirm: ((password: string) => void) | null
-  onClose: (() => void) | null
-  openPopup: (
-    meetingId: number,
-    onConfirm: (password: string) => void,
-    onClose: () => void,
-  ) => void
+  openPopup: (meetingId: number, onConfirm: (password: string) => void) => void
   closePopup: () => void
+  closePopupAndRedirect: () => void
 }
 
 export const usePasswordPopupStore = create<PasswordPopupStore>((set) => ({
   isOpen: false,
   meetingId: null,
   onConfirm: null,
-  onClose: null,
-  openPopup: (meetingId, onConfirm, onClose) =>
-    set({ isOpen: true, meetingId, onConfirm, onClose }),
-  closePopup: () =>
-    set({ isOpen: false, meetingId: null, onConfirm: null, onClose: null }),
+  openPopup: (meetingId, onConfirm) =>
+    set({ isOpen: true, meetingId, onConfirm }),
+  closePopup: () => set({ isOpen: false, meetingId: null, onConfirm: null }),
+  closePopupAndRedirect: () => {
+    set({ isOpen: false, meetingId: null, onConfirm: null })
+    window.location.href = '/'
+  },
 }))
 
 export default usePasswordPopupStore

--- a/src/stores/usePasswordPopupStore.ts
+++ b/src/stores/usePasswordPopupStore.ts
@@ -1,0 +1,27 @@
+import create from 'zustand'
+
+type PasswordPopupStore = {
+  isOpen: boolean
+  meetingId: number | null
+  onConfirm: ((password: string) => void) | null
+  onClose: (() => void) | null
+  openPopup: (
+    meetingId: number,
+    onConfirm: (password: string) => void,
+    onClose: () => void,
+  ) => void
+  closePopup: () => void
+}
+
+export const usePasswordPopupStore = create<PasswordPopupStore>((set) => ({
+  isOpen: false,
+  meetingId: null,
+  onConfirm: null,
+  onClose: null,
+  openPopup: (meetingId, onConfirm, onClose) =>
+    set({ isOpen: true, meetingId, onConfirm, onClose }),
+  closePopup: () =>
+    set({ isOpen: false, meetingId: null, onConfirm: null, onClose: null }),
+}))
+
+export default usePasswordPopupStore


### PR DESCRIPTION
#56 

## 변경사항
- 암호 입력 팝업창을 통해 모임에 재입장할 수 있는 기능을 추가했습니다.

## 세부사항
- 암호입력팝업 컴포넌트 구현을 위해 Popup 컴포넌트에 속성을 추가했습니다.
- 암호입력팝업의 렌더링을 위해 전역상태를 추가했습니다.

## 참고사항
- 토큰 갱신, 재입장 로직들이 apiUtils 의 apiCall 에 모두 포함되어있어서, 전체적인 api 호출 로직들에 대한 검토가 필요합니다.
