### PR TITLE
fix: 카메라 뷰 크기 조정 문제 해결

### DIFF
--- a/src/app/meeting/photo-capture/_components/CameraView.tsx
+++ b/src/app/meeting/photo-capture/_components/CameraView.tsx
@@ -33,17 +33,18 @@ function CameraView({
       const video = videoRef.current
       const container = video.parentElement
       if (container) {
-        const containerAspect = container.clientWidth / container.clientHeight
+        const containerWidth = container.clientWidth
+        const containerHeight = container.clientHeight
         const videoAspect = video.videoWidth / video.videoHeight
 
         let newWidth
         let newHeight
 
-        if (containerAspect > videoAspect) {
-          newHeight = container.clientHeight
+        if (containerWidth / containerHeight > videoAspect) {
+          newHeight = containerHeight
           newWidth = newHeight * videoAspect
         } else {
-          newWidth = container.clientWidth
+          newWidth = containerWidth
           newHeight = newWidth / videoAspect
         }
 
@@ -51,6 +52,25 @@ function CameraView({
       }
     }
   }, [videoRef])
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (video) {
+      const resizeObserver = new ResizeObserver(() => {
+        adjustVideoSize()
+      })
+      resizeObserver.observe(video)
+      return () => resizeObserver.disconnect()
+    }
+    return undefined
+  }, [videoRef, adjustVideoSize])
+
+  const handleToggleCamera = useCallback(() => {
+    onToggleCamera()
+    setTimeout(() => {
+      adjustVideoSize()
+    }, 100)
+  }, [onToggleCamera, adjustVideoSize])
 
   useEffect(() => {
     const video = videoRef.current
@@ -77,6 +97,14 @@ function CameraView({
     }
     return undefined
   }, [currentMission, hideTooltip, showTooltip])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      adjustVideoSize()
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [adjustVideoSize])
 
   const missionButton = useMemo(
     () => (
@@ -167,7 +195,7 @@ function CameraView({
         <div className="flex items-center justify-center w-full mt-5">
           <button
             type="button"
-            onClick={onToggleCamera}
+            onClick={handleToggleCamera}
             className="flex items-center justify-center w-1/3"
           >
             <Image


### PR DESCRIPTION
## 변경사항
- 카메라 뷰 컴포넌트의 크기 조정 로직 개선
- 카메라 뷰에 처음 진입하거나 다시 돌아올 때 발생하는 컨테이너 잘림 현상을 해결

## 세부사항
- 컴포넌트 마운트, 또는 카메라 전면후면 토글 버튼 클릭 시 비디오 사이즈 조정 함수를 지연시켜, 비디오 스트림이 완전히 로드된 후 크기 조정이 이루어지도록 했습니다.

## 참고사항
- 동일한 이슈가 다시 발생한다면 이슈로 등록부탁드립니다.
