### PR TITLE
Refactor: API 호출 및 데이터 관리 로직 분리

### DIFF
--- a/src/apis/missionApi.ts
+++ b/src/apis/missionApi.ts
@@ -1,128 +1,27 @@
-import {
-  useMutation,
-  UseMutationOptions,
-  useQuery,
-  useQueryClient,
-  UseQueryOptions,
-} from '@tanstack/react-query'
-import { apiCall, ApiError, ApiResponse } from './apiUtils'
+import { apiCall } from './apiUtils'
 
-type GetRandomMissionsResponse = ApiResponse<
-  Array<{
-    randomMissionId: number
-    content: string
-  }>
->
-
-type GetCompletedMissionsResponse = ApiResponse<
-  Array<{
-    missionId: number
-    content: string
-  }>
->
-
-type GetInCompleteMissionResponse = ApiResponse<
-  Array<{
-    missionId: number
-    content: string
-  }>
->
-
-type GetParticipantMissionsResponse = ApiResponse<
-  Array<{
-    missionId: number
-    content: string
-  }>
->
-type GetLeaderMissionResponse = ApiResponse<
-  Array<{
-    missionId: number
-    content: string
-    hasParticipants: boolean
-  }>
->
-
-type DeleteMissionResponse = ApiResponse<string>
-
-export const useGetRandomMissions = (
-  options?: UseQueryOptions<GetRandomMissionsResponse, ApiError>,
-) =>
-  useQuery<GetRandomMissionsResponse, ApiError>({
-    queryKey: ['missions', 'random'],
-    queryFn: () => apiCall('/random-missions'),
-    retry: false,
-    ...options,
-  })
-
-export const useGetCompletedMissions = (
-  meetingId: number,
-  options?: UseQueryOptions<GetCompletedMissionsResponse, ApiError>,
-) =>
-  useQuery<GetCompletedMissionsResponse, ApiError>({
-    queryKey: ['missions', meetingId, 'completed'],
-    queryFn: () => apiCall(`/meetings/${meetingId}/missions/completed`),
-    enabled: !!meetingId,
-    retry: false,
-    ...options,
-  })
-
-export const useGetInCompleteMissions = (
-  meetingId: number,
-  options?: UseQueryOptions<GetInCompleteMissionResponse, ApiError>,
-) =>
-  useQuery<GetInCompleteMissionResponse, ApiError>({
-    queryKey: ['missions', meetingId, 'incomplete'],
-    queryFn: () => apiCall(`/meetings/${meetingId}/missions/incomplete`),
-    enabled: !!meetingId,
-    retry: false,
-    ...options,
-  })
-
-export const useGetParticipantMissions = (
-  meetingId: number,
-  options?: UseQueryOptions<GetParticipantMissionsResponse, ApiError>,
-) =>
-  useQuery<GetParticipantMissionsResponse, ApiError>({
-    queryKey: ['missions', meetingId],
-    queryFn: () => apiCall(`/meetings/${meetingId}/missions`),
-    enabled: !!meetingId,
-    retry: false,
-    ...options,
-  })
-
-export const useGetLeaderMission = (
-  meetingId: number,
-  options?: UseQueryOptions<GetLeaderMissionResponse, ApiError>,
-) =>
-  useQuery<GetLeaderMissionResponse, ApiError>({
-    queryKey: ['missions', meetingId, 'leader'],
-    queryFn: () => apiCall(`/meetings/${meetingId}/missions/leader`),
-    enabled: !!meetingId,
-    retry: false,
-    ...options,
-  })
-
-type DeleteMissionVariables = {
-  meetingId: number
-  missionId: number
+export interface CreateMissionRequest {
+  content: string
 }
 
-export const useDeleteMission = (
-  options?: Omit<
-    UseMutationOptions<DeleteMissionResponse, ApiError, DeleteMissionVariables>,
-    'mutationFn'
-  >,
-) => {
-  const queryClient = useQueryClient()
+export const getRandomMissions = () => apiCall('/random-missions')
 
-  return useMutation<DeleteMissionResponse, ApiError, DeleteMissionVariables>({
-    mutationFn: ({ meetingId, missionId }) =>
-      apiCall(`/meetings/${meetingId}/missions/${missionId}`, 'DELETE'),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['missions', variables.meetingId, 'leader'],
-      })
-    },
-    ...options,
-  })
-}
+export const getCompletedMissions = (meetingId: number) =>
+  apiCall(`/meetings/${meetingId}/missions/completed`)
+
+export const getIncompleteMissions = (meetingId: number) =>
+  apiCall(`/meetings/${meetingId}/missions/incomplete`)
+
+export const getParticipantMissions = (meetingId: number) =>
+  apiCall(`/meetings/${meetingId}/missions`)
+
+export const getLeaderMissions = (meetingId: number) =>
+  apiCall(`/meetings/${meetingId}/missions/leader`)
+
+export const deleteMission = (meetingId: number, missionId: number) =>
+  apiCall(`/meetings/${meetingId}/missions/${missionId}`, 'DELETE')
+
+export const createMission = async (
+  meetingId: number,
+  data: CreateMissionRequest,
+) => apiCall(`/meetings/${meetingId}/missions`, 'POST', data)

--- a/src/apis/participantsApi.ts
+++ b/src/apis/participantsApi.ts
@@ -1,64 +1,19 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
-import useUserStore from '@/stores/useUserStore'
-import { apiCall, ApiResponse, ApiError } from './apiUtils'
+import {
+  GetParticipantsMeResponse,
+  ParticipantsResponse,
+} from '@/types/participants'
+import { apiCall } from './apiUtils'
 
-interface Participant {
-  participantId: number
-  role: string
-  nickname: string
-  shootCount: number
-}
-
-type ParticipantsResponse = ApiResponse<{
-  nextCursorId: number
-  data: Participant[]
-  count: number
-  hasNext: boolean
-}>
-
-type GetParticipantsMeResponse = ApiResponse<{
-  participantId: number
-  role: string
-  nickname: string
-  shootCount: number
-}>
-
-export const useParticipants = (meetingId: number, limit: number = 10) =>
-  useInfiniteQuery<ParticipantsResponse, ApiError>({
-    queryKey: ['participants', meetingId, limit],
-    queryFn: async ({ pageParam = 0 }) =>
-      apiCall(
-        `/meetings/${meetingId}/participants?cursorId=${pageParam}&limit=${limit}`,
-      ),
-    getNextPageParam: (lastPage) =>
-      lastPage.data.hasNext ? lastPage.data.nextCursorId : undefined,
-    initialPageParam: 0,
-  })
-
-export const useGetParticipantsMe = (
+export const getParticipants = async (
   meetingId: number,
-  hasTokens: boolean = true,
-  isEnabled: boolean = true,
-) => {
-  const { setParticipantId, setNickname, setRole, setShootCount } =
-    useUserStore()
+  cursorId: number = 0,
+  limit: number = 10,
+): Promise<ParticipantsResponse> =>
+  apiCall(
+    `/meetings/${meetingId}/participants?cursorId=${cursorId}&limit=${limit}`,
+  )
 
-  return useQuery<GetParticipantsMeResponse, ApiError>({
-    queryKey: ['participants', meetingId, 'me'],
-    queryFn: async () => {
-      const response = await apiCall(`/meetings/${meetingId}/participants/me`)
-      const { participantId, nickname, role, shootCount } = response.data
-      setParticipantId(participantId)
-      setNickname(nickname)
-      setRole(role as 'LEADER' | 'PARTICIPANT')
-      setShootCount(shootCount)
-
-      return response
-    },
-    enabled: !!meetingId && isEnabled && hasTokens === true,
-    retry: false,
-    refetchOnWindowFocus: false,
-  })
-}
-
-export default useParticipants
+export const getParticipantsMe = async (
+  meetingId: number,
+): Promise<GetParticipantsMeResponse> =>
+  apiCall(`/meetings/${meetingId}/participants/me`)

--- a/src/apis/snapApi.ts
+++ b/src/apis/snapApi.ts
@@ -1,27 +1,4 @@
-import {
-  useMutation,
-  UseMutationOptions,
-  useQuery,
-  UseQueryOptions,
-} from '@tanstack/react-query'
-import { ApiResponse, ApiError, apiCall } from './apiUtils'
-
-type UploadSnapResponse = ApiResponse<{ snapId: number; snapUrl: string }>
-
-type GetSnapDetailResponse = ApiResponse<{
-  snapId: number
-  snapUrl: string
-  shootDate: string
-  type: 'SIMPLE' | 'MEETING_MISSION' | 'RANDOM_MISSION'
-  photographer: {
-    participantId: number
-    nickname: string
-  }
-  mission?: {
-    missionId?: number
-    content?: string
-  }
-}>
+import { apiCall } from './apiUtils'
 
 interface SnapData {
   shootDate: string
@@ -29,59 +6,89 @@ interface SnapData {
   missionId?: number
 }
 
-interface UploadSnapParams {
-  meetingId: number
-  snapData: SnapData
-  image: File
-  missionType: 'random' | 'select' | null
+export const uploadSimpleSnap = async (
+  meetingId: number,
+  snapData: SnapData,
+  image: File,
+) => {
+  const formData = new FormData()
+  formData.append(
+    'snap',
+    new Blob([JSON.stringify(snapData)], { type: 'application/json' }),
+  )
+  formData.append('image', image)
+
+  const response = await fetch(`/api/v1/meetings/${meetingId}/snaps/simple`, {
+    method: 'POST',
+    body: formData,
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json()
+    throw errorData
+  }
+
+  return response.json()
 }
 
-export const useUploadSnap = (
-  options?: UseMutationOptions<UploadSnapResponse, ApiError, UploadSnapParams>,
-) =>
-  useMutation<UploadSnapResponse, ApiError, UploadSnapParams>({
-    mutationFn: async ({ meetingId, snapData, image, missionType }) => {
-      let endpoint = '/snaps/simple'
-
-      if (missionType === 'random') {
-        endpoint = '/snaps/random-mission'
-      } else if (missionType === 'select') {
-        endpoint = '/snaps/meeting-mission'
-      }
-      console.log('snapData', snapData)
-
-      const formData = new FormData()
-      formData.append(
-        'snap',
-        new Blob([JSON.stringify(snapData)], { type: 'application/json' }),
-      )
-      formData.append('image', image)
-
-      const response = await fetch(`/api/v1/meetings/${meetingId}${endpoint}`, {
-        method: 'POST',
-        body: formData,
-        credentials: 'include',
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw errorData
-      }
-
-      return response.json()
-    },
-    ...options,
-  })
-
-export const useGetSnapDetail = (
+export const uploadRandomMissionSnap = async (
   meetingId: number,
-  snapId: number,
-  options?: UseQueryOptions<GetSnapDetailResponse, ApiError>,
-) =>
-  useQuery<GetSnapDetailResponse, ApiError>({
-    queryKey: ['snaps', meetingId, snapId],
-    queryFn: () => apiCall(`/meetings/${meetingId}/snaps/${snapId}`),
-    enabled: !!meetingId && !!snapId,
-    retry: false,
-    ...options,
-  })
+  snapData: SnapData,
+  image: File,
+) => {
+  const formData = new FormData()
+  formData.append(
+    'snap',
+    new Blob([JSON.stringify(snapData)], { type: 'application/json' }),
+  )
+  formData.append('image', image)
+
+  const response = await fetch(
+    `/api/v1/meetings/${meetingId}/snaps/random-mission`,
+    {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json()
+    throw errorData
+  }
+
+  return response.json()
+}
+
+export const uploadMeetingMissionSnap = async (
+  meetingId: number,
+  snapData: SnapData,
+  image: File,
+) => {
+  const formData = new FormData()
+  formData.append(
+    'snap',
+    new Blob([JSON.stringify(snapData)], { type: 'application/json' }),
+  )
+  formData.append('image', image)
+
+  const response = await fetch(
+    `/api/v1/meetings/${meetingId}/snaps/meeting-mission`,
+    {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json()
+    throw errorData
+  }
+
+  return response.json()
+}
+
+export const getSnapDetail = (meetingId: number, snapId: number) =>
+  apiCall(`/meetings/${meetingId}/snaps/${snapId}`)

--- a/src/app/AuthGuard.tsx
+++ b/src/app/AuthGuard.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { useGetParticipantsMe } from '@/apis/participantsApi'
 import Loading from '@/components/Loading'
+import useParticipantsMe from '@/hooks/useParticipantsMe'
 import useTokens from '@/hooks/useTokens'
 import useMeetingStore from '@/stores/useMeetingStore'
 
@@ -26,7 +26,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     refetch: refetchTokens,
   } = useTokens(meetingData?.meetingId ?? 0)
 
-  const { refetch: checkAuth } = useGetParticipantsMe(
+  const { refetch: checkAuth } = useParticipantsMe(
     meetingData?.meetingId ?? 0,
     tokenData?.hasTokens ?? false,
     false,

--- a/src/app/entry-meeting/[meetingCode]/page.tsx
+++ b/src/app/entry-meeting/[meetingCode]/page.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { useCheckMeetingLink } from '@/apis/meetingApi'
 import Loading from '@/components/Loading'
+import useCheckMeetingLink from '@/hooks/useCheckMeetingLink'
 import useMeetingStore from '@/stores/useMeetingStore'
 import {
   LinkInput,
@@ -26,12 +26,12 @@ function EntryMeeting() {
     meetingCode ?? '',
     {
       enabled: !!meetingCode,
-      queryKey: ['checkMeetingLink', meetingCode],
+      queryKey: ['checkMeetingLink', meetingCode ?? ''],
     },
   )
 
   useEffect(() => {
-    if (meetingCode && isSuccess && data) {
+    if (meetingCode && isSuccess && data?.data) {
       setMeetingData(data.data)
       setPage(1)
     } else if (!meetingCode) {

--- a/src/app/entry-meeting/_components/LinkInput.tsx
+++ b/src/app/entry-meeting/_components/LinkInput.tsx
@@ -3,10 +3,10 @@ import { useForm } from 'react-hook-form'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { z } from 'zod'
-import { useCheckMeetingLink } from '@/apis/meetingApi'
 import { Button } from '@/components/Button'
 import Callout from '@/components/Callout'
 import { TextInput } from '@/components/Inputs/TextInput'
+import useCheckMeetingLink from '@/hooks/useCheckMeetingLink'
 import useDebounce from '@/hooks/useDebounce'
 import useMeetingStore from '@/stores/useMeetingStore'
 import BackIcon from 'public/icons/back.svg'
@@ -39,8 +39,13 @@ function LinkInput({ onEnterClick, onHomeClick }: LinkInputProps) {
   const linkValue = watch('link')
   const debouncedLink = useDebounce(linkValue, 500)
 
-  const { data, isLoading, isSuccess, isError, error } =
-    useCheckMeetingLink(debouncedLink)
+  const { data, isLoading, isSuccess, isError, error } = useCheckMeetingLink(
+    debouncedLink,
+    {
+      enabled: !!debouncedLink && debouncedLink.length > 0,
+      queryKey: ['checkMeetingLink', debouncedLink],
+    },
+  )
 
   useEffect(() => {
     if (data) {

--- a/src/app/entry-meeting/_components/MeetingInfo.tsx
+++ b/src/app/entry-meeting/_components/MeetingInfo.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect } from 'react'
 import dayjs from 'dayjs'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { useCheckMeetingLink } from '@/apis/meetingApi'
-import { useGetParticipantsMe } from '@/apis/participantsApi'
 import { Button } from '@/components/Button'
 import Loading from '@/components/Loading'
 import { IMAGE_BASE_URL } from '@/constant/base_url'
+import useCheckMeetingLink from '@/hooks/useCheckMeetingLink'
+import useParticipantsMe from '@/hooks/useParticipantsMe'
 import useTokens from '@/hooks/useTokens'
 import useMeetingStore from '@/stores/useMeetingStore'
 import BackIcon from 'public/icons/back.svg'
@@ -34,12 +34,19 @@ function MeetingInfo({
   const meetingSymbolColor = useMeetingStore(
     (state) => state.meetingData?.symbolColor,
   )
-  const { data, isLoading, isSuccess } = useCheckMeetingLink(meetingCode || '')
+  const { data, isLoading, isSuccess } = useCheckMeetingLink(
+    meetingCode || '',
+    {
+      enabled: !!meetingCode,
+      queryKey: ['checkMeetingLink', meetingCode ?? ''],
+      retry: false,
+    },
+  )
   const { data: tokenData, isSuccess: tokenCheckSuccess } = useTokens(
     meetingData?.meetingId ?? 0,
   )
 
-  const { refetch: checkMyInfo } = useGetParticipantsMe(
+  const { refetch: checkMyInfo } = useParticipantsMe(
     meetingData?.meetingId ?? 0,
     tokenData?.hasTokens ?? false,
     false,

--- a/src/app/entry-meeting/_components/NicknameInput.tsx
+++ b/src/app/entry-meeting/_components/NicknameInput.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import Image from 'next/image'
 import { z } from 'zod'
-import { useCheckNickname, useJoinMeeting } from '@/apis/meetingApi'
+import { checkNickname, joinMeeting } from '@/apis/meetingApi'
 import { Button } from '@/components/Button'
 import { TextInput } from '@/components/Inputs/TextInput'
 import useDebounce from '@/hooks/useDebounce'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
+import { ApiError } from '@/types/api'
+import { CheckNicknameResponse, JoinMeetingResponse } from '@/types/meeting'
 import BackIcon from 'public/icons/back.svg'
 
 const nicknameSchema = z.object({
@@ -71,11 +74,41 @@ function NicknameInput({
     isSuccess,
     isError,
     error: nicknameCheckError,
-  } = useCheckNickname(meetingId!, debouncedNickname, {
-    queryKey: ['checkNickname', meetingId, debouncedNickname],
+  } = useQuery<CheckNicknameResponse, ApiError>({
+    queryKey: ['nickname', meetingId, debouncedNickname],
+    queryFn: () => checkNickname(meetingId!, debouncedNickname),
     enabled: isNicknameValid && debouncedNickname.length > 0,
+    retry: false,
   })
-  const joinMeetingMutation = useJoinMeeting()
+
+  const joinMeetingMutation = useMutation<
+    JoinMeetingResponse,
+    ApiError,
+    {
+      meetingId: number
+      nickname: string
+      role: string
+    }
+  >({
+    mutationFn: ({ meetingId: id, nickname, role }) =>
+      joinMeeting(id, nickname, role),
+    onSuccess: (data) => {
+      setNickname(nicknameValue)
+      setParticipantId(data.data.participantId)
+      onEnterClick()
+    },
+    onError: (error) => {
+      console.error('Error joining meeting:', error)
+      if (error.error?.code === 'MEETING_JOIN_DENIED') {
+        setApiErrorMessage('이미 끝난 모임에는 참여할 수 없습니다.')
+      } else {
+        setApiErrorMessage(
+          '모임 참가 중 오류가 발생했습니다. 다시 시도해주세요.',
+        )
+      }
+      setSuccessMessage(undefined)
+    },
+  })
 
   useEffect(() => {
     if (!isNicknameValid) {
@@ -111,27 +144,11 @@ function NicknameInput({
   const errorMessage = errors.nickname?.message || apiErrorMessage || undefined
 
   const onSubmit = handleSubmit((formData) => {
-    joinMeetingMutation.mutate(
-      {
-        meetingId: meetingId!,
-        nickname: formData.nickname,
-        role: userRole,
-      },
-      {
-        onSuccess: (joinMeetingData) => {
-          setNickname(formData.nickname)
-          setParticipantId(joinMeetingData.data.participantId)
-          onEnterClick()
-        },
-        onError: (joinMeetingError) => {
-          console.error('Error joining meeting:', joinMeetingError)
-          setApiErrorMessage(
-            '모임 참가 중 오류가 발생했습니다. 다시 시도해주세요.',
-          )
-          setSuccessMessage(undefined)
-        },
-      },
-    )
+    joinMeetingMutation.mutate({
+      meetingId: meetingId!,
+      nickname: formData.nickname,
+      role: userRole,
+    })
   })
 
   return (

--- a/src/app/entry-meeting/_components/PasswordInput.tsx
+++ b/src/app/entry-meeting/_components/PasswordInput.tsx
@@ -1,18 +1,21 @@
 import React, { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
 import Image from 'next/image'
 import { z } from 'zod'
-import {
-  useValidateLeaderAuthKey,
-  useValidatePassword,
-} from '@/apis/meetingApi'
+import { validateLeaderAuthKey, validatePassword } from '@/apis/meetingApi'
 import { Button } from '@/components/Button'
 import { TextInput } from '@/components/Inputs/TextInput'
 import { ToggleSwitch } from '@/components/ToogleSwitch'
 import useDebounce from '@/hooks/useDebounce'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
+import { ApiError } from '@/types/api'
+import {
+  ValidateLeaderAuthKeyResponse,
+  ValidatePasswordResponse,
+} from '@/types/meeting'
 import CrownSvg from 'public/icons/CrownSvg'
 import BackIcon from 'public/icons/back.svg'
 
@@ -83,8 +86,28 @@ function PasswordInput({
   const debouncedPassword = useDebounce(passwordValue, 500)
   const debouncedLeaderAuthKey = useDebounce(leaderAuthKeyValue, 500)
 
-  const validatePassword = useValidatePassword()
-  const validateLeaderAuthKey = useValidateLeaderAuthKey()
+  const errorMessagePassword =
+    apiErrorMessagePassword || errors.password?.message || null
+  const errorMessageLeaderAuthKey =
+    apiErrorMessageLeaderAuthKey || errors.leaderAuthKey?.message || null
+
+  const validatePasswordMutation = useMutation<
+    ValidatePasswordResponse,
+    ApiError,
+    { meetingId: number; password: string }
+  >({
+    mutationFn: ({ meetingId, password }) =>
+      validatePassword(meetingId, password),
+  })
+
+  const validateLeaderAuthKeyMutation = useMutation<
+    ValidateLeaderAuthKeyResponse,
+    ApiError,
+    { meetingId: number; leaderAuthKey: string }
+  >({
+    mutationFn: ({ meetingId, leaderAuthKey }) =>
+      validateLeaderAuthKey(meetingId, leaderAuthKey),
+  })
 
   const handleEnterClick = () => {
     if (isLeader && isPasswordValid && isLeaderAuthKeyValid) {
@@ -97,7 +120,7 @@ function PasswordInput({
 
   useEffect(() => {
     if (debouncedPassword && debouncedPassword.length >= 4) {
-      validatePassword.mutate({
+      validatePasswordMutation.mutate({
         meetingId: currentMeetingId!,
         password: debouncedPassword,
       })
@@ -105,7 +128,7 @@ function PasswordInput({
       setApiErrorMessagePassword(null)
       setIsPasswordValid(false)
     }
-  }, [debouncedPassword])
+  }, [debouncedPassword, currentMeetingId])
 
   useEffect(() => {
     if (
@@ -113,7 +136,7 @@ function PasswordInput({
       debouncedLeaderAuthKey &&
       debouncedLeaderAuthKey.length === 4
     ) {
-      validateLeaderAuthKey.mutate({
+      validateLeaderAuthKeyMutation.mutate({
         meetingId: currentMeetingId!,
         leaderAuthKey: debouncedLeaderAuthKey,
       })
@@ -121,43 +144,46 @@ function PasswordInput({
       setApiErrorMessageLeaderAuthKey(null)
       setIsLeaderAuthKeyValid(false)
     }
-  }, [isLeader, debouncedLeaderAuthKey])
+  }, [isLeader, debouncedLeaderAuthKey, currentMeetingId])
 
   useEffect(() => {
-    if (validatePassword.isError) {
-      if (validatePassword.error) {
+    if (validatePasswordMutation.isError) {
+      if (validatePasswordMutation.error) {
         if (
-          validatePassword.error.error.code === 'MEETING_INVALIDATE_PASSWORD'
+          validatePasswordMutation.error.error.code ===
+          'MEETING_INVALIDATE_PASSWORD'
         ) {
           setApiErrorMessagePassword('암호가 일치하지 않습니다.')
         } else {
-          setApiErrorMessagePassword(validatePassword.error.error.message)
+          setApiErrorMessagePassword(
+            validatePasswordMutation.error.error.message,
+          )
         }
       } else {
         setApiErrorMessagePassword('오류가 발생했습니다. 다시 시도해주세요.')
       }
       setIsPasswordValid(false)
-    } else if (validatePassword.isSuccess) {
+    } else if (validatePasswordMutation.isSuccess) {
       setApiErrorMessagePassword(null)
       setIsPasswordValid(true)
     }
   }, [
-    validatePassword.isError,
-    validatePassword.isSuccess,
-    validatePassword.error,
+    validatePasswordMutation.isError,
+    validatePasswordMutation.isSuccess,
+    validatePasswordMutation.error,
   ])
 
   useEffect(() => {
-    if (validateLeaderAuthKey.isError) {
-      if (validateLeaderAuthKey.error) {
+    if (validateLeaderAuthKeyMutation.isError) {
+      if (validateLeaderAuthKeyMutation.error) {
         if (
-          validateLeaderAuthKey.error.error.code ===
+          validateLeaderAuthKeyMutation.error.error.code ===
           'MEETING_INVALIDATE_AUTH_KEY'
         ) {
           setApiErrorMessageLeaderAuthKey('암호가 일치하지 않습니다.')
         } else {
           setApiErrorMessageLeaderAuthKey(
-            validateLeaderAuthKey.error.error.message,
+            validateLeaderAuthKeyMutation.error.error.message,
           )
         }
       } else {
@@ -166,25 +192,20 @@ function PasswordInput({
         )
       }
       setIsLeaderAuthKeyValid(false)
-    } else if (validateLeaderAuthKey.isSuccess) {
+    } else if (validateLeaderAuthKeyMutation.isSuccess) {
       setApiErrorMessageLeaderAuthKey(null)
       setIsLeaderAuthKeyValid(true)
     }
   }, [
-    validateLeaderAuthKey.isError,
-    validateLeaderAuthKey.isSuccess,
-    validateLeaderAuthKey.error,
+    validateLeaderAuthKeyMutation.isError,
+    validateLeaderAuthKeyMutation.isSuccess,
+    validateLeaderAuthKeyMutation.error,
   ])
-
-  const errorMessagePassword =
-    apiErrorMessagePassword || errors.password?.message || null
-  const errorMessageLeaderAuthKey =
-    apiErrorMessageLeaderAuthKey || errors.leaderAuthKey?.message || null
 
   useEffect(() => {
     reset({ password: '', leaderAuthKey: '' })
-    validatePassword.reset()
-    validateLeaderAuthKey.reset()
+    validatePasswordMutation.reset()
+    validateLeaderAuthKeyMutation.reset()
     setIsPasswordValid(false)
     setIsLeaderAuthKeyValid(false)
   }, [isLeader, reset])
@@ -226,7 +247,7 @@ function PasswordInput({
           success={isPasswordValid}
           successMessage="비밀번호 입력 완료!"
           error={errorMessagePassword}
-          checking={validatePassword.isPending}
+          checking={validatePasswordMutation.isPending}
         />
         {isLeader && (
           <TextInput
@@ -238,7 +259,7 @@ function PasswordInput({
             success={isLeaderAuthKeyValid}
             successMessage="인증키 입력 완료!"
             error={errorMessageLeaderAuthKey}
-            checking={validateLeaderAuthKey.isPending}
+            checking={validateLeaderAuthKeyMutation.isPending}
           />
         )}
       </div>

--- a/src/app/entry-meeting/_hooks/usePasswordValidation.ts
+++ b/src/app/entry-meeting/_hooks/usePasswordValidation.ts
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
 import { z } from 'zod'
-import {
-  useValidateLeaderAuthKey,
-  useValidatePassword,
-} from '@/apis/meetingApi'
+import { validateLeaderAuthKey, validatePassword } from '@/apis/meetingApi'
 import useDebounce from '@/hooks/useDebounce'
+import { ApiError } from '@/types/api'
+import {
+  ValidateLeaderAuthKeyResponse,
+  ValidatePasswordResponse,
+} from '@/types/meeting'
 
 const passwordSchema = z.object({
   password: z.string().min(6, '최소 6자 이상 입력해주세요.'),
@@ -41,12 +44,47 @@ export const usePasswordValidation = (currentMeetingId: number) => {
   const debouncedPassword = useDebounce(passwordValue, 500)
   const debouncedLeaderAuthKey = useDebounce(leaderAuthKeyValue, 500)
 
-  const validatePassword = useValidatePassword()
-  const validateLeaderAuthKey = useValidateLeaderAuthKey()
+  const validatePasswordMutation = useMutation<
+    ValidatePasswordResponse,
+    ApiError,
+    { meetingId: number; password: string }
+  >({
+    mutationFn: ({ meetingId, password }) =>
+      validatePassword(meetingId, password),
+    onError: (error) => {
+      setApiErrorMessagePassword(
+        error.error?.code === 'MEETING_INVALIDATE_PASSWORD'
+          ? '암호가 일치하지 않습니다.'
+          : error.error?.message || '오류가 발생했습니다. 다시 시도해주세요.',
+      )
+    },
+    onSuccess: () => {
+      setApiErrorMessagePassword(null)
+    },
+  })
+
+  const validateLeaderAuthKeyMutation = useMutation<
+    ValidateLeaderAuthKeyResponse,
+    ApiError,
+    { meetingId: number; leaderAuthKey: string }
+  >({
+    mutationFn: ({ meetingId, leaderAuthKey }) =>
+      validateLeaderAuthKey(meetingId, leaderAuthKey),
+    onError: (error) => {
+      setApiErrorMessageLeaderAuthKey(
+        error.error?.code === 'MEETING_INVALIDATE_AUTH_KEY'
+          ? '암호가 일치하지 않습니다.'
+          : error.error?.message || '오류가 발생했습니다. 다시 시도해주세요.',
+      )
+    },
+    onSuccess: () => {
+      setApiErrorMessageLeaderAuthKey(null)
+    },
+  })
 
   useEffect(() => {
     if (debouncedPassword && debouncedPassword.length >= 6) {
-      validatePassword.mutate({
+      validatePasswordMutation.mutate({
         meetingId: currentMeetingId,
         password: debouncedPassword,
       })
@@ -61,7 +99,7 @@ export const usePasswordValidation = (currentMeetingId: number) => {
       debouncedLeaderAuthKey &&
       debouncedLeaderAuthKey.length === 4
     ) {
-      validateLeaderAuthKey.mutate({
+      validateLeaderAuthKeyMutation.mutate({
         meetingId: currentMeetingId,
         leaderAuthKey: debouncedLeaderAuthKey,
       })
@@ -71,44 +109,9 @@ export const usePasswordValidation = (currentMeetingId: number) => {
   }, [isLeader, debouncedLeaderAuthKey, currentMeetingId])
 
   useEffect(() => {
-    if (validatePassword.isError) {
-      setApiErrorMessagePassword(
-        validatePassword.error?.error?.code === 'MEETING_INVALIDATE_PASSWORD'
-          ? '암호가 일치하지 않습니다.'
-          : validatePassword.error?.error?.message ||
-              '오류가 발생했습니다. 다시 시도해주세요.',
-      )
-    } else if (validatePassword.isSuccess) {
-      setApiErrorMessagePassword(null)
-    }
-  }, [
-    validatePassword.isError,
-    validatePassword.isSuccess,
-    validatePassword.error,
-  ])
-
-  useEffect(() => {
-    if (validateLeaderAuthKey.isError) {
-      setApiErrorMessageLeaderAuthKey(
-        validateLeaderAuthKey.error?.error?.code ===
-          'MEETING_INVALIDATE_AUTH_KEY'
-          ? '암호가 일치하지 않습니다.'
-          : validateLeaderAuthKey.error?.error?.message ||
-              '오류가 발생했습니다. 다시 시도해주세요.',
-      )
-    } else if (validateLeaderAuthKey.isSuccess) {
-      setApiErrorMessageLeaderAuthKey(null)
-    }
-  }, [
-    validateLeaderAuthKey.isError,
-    validateLeaderAuthKey.isSuccess,
-    validateLeaderAuthKey.error,
-  ])
-
-  useEffect(() => {
     reset({ password: '', leaderAuthKey: '' })
-    validatePassword.reset()
-    validateLeaderAuthKey.reset()
+    validatePasswordMutation.reset()
+    validateLeaderAuthKeyMutation.reset()
   }, [isLeader, reset])
 
   return {
@@ -118,8 +121,8 @@ export const usePasswordValidation = (currentMeetingId: number) => {
     setIsLeader,
     apiErrorMessagePassword,
     apiErrorMessageLeaderAuthKey,
-    validatePassword,
-    validateLeaderAuthKey,
+    validatePassword: validatePasswordMutation,
+    validateLeaderAuthKey: validateLeaderAuthKeyMutation,
   }
 }
 

--- a/src/app/meeting/info/_components/MeetingDetail.tsx
+++ b/src/app/meeting/info/_components/MeetingDetail.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useParticipants } from '@/apis/participantsApi'
+import { getParticipants } from '@/apis/participantsApi'
 import Loading from '@/components/Loading'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
+import { ApiError } from '@/types/api'
+import { ParticipantsResponse } from '@/types/participants'
 import Edit from 'public/icons/edit.svg'
 import Leader from 'public/icons/leader.svg'
 
@@ -28,7 +31,20 @@ function MeetingDetail() {
     fetchNextPage,
     hasNextPage,
     isFetching,
-  } = useParticipants(meetingData?.meetingId ?? 0, limit)
+  } = useInfiniteQuery<ParticipantsResponse, ApiError>({
+    queryKey: ['participants', meetingData?.meetingId, limit],
+    queryFn: ({ pageParam = 0 }) => {
+      const meetingId = meetingData?.meetingId
+      if (!meetingId) {
+        throw new Error('Meeting ID not found')
+      }
+      return getParticipants(meetingId, pageParam as number, limit)
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.data.hasNext ? lastPage.data.nextCursorId : undefined,
+    initialPageParam: 0,
+    enabled: !!meetingData?.meetingId,
+  })
 
   const observer = useRef<IntersectionObserver | null>(null)
   const lastParticipantRef = useCallback(

--- a/src/app/meeting/info/_components/MeetingRaising.tsx
+++ b/src/app/meeting/info/_components/MeetingRaising.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useGetMeetingPassword, useShareMeeting } from '@/apis/meetingApi'
-import { useGetParticipantMissions } from '@/apis/missionApi'
+import { getMeetingPassword, shareMeeting } from '@/apis/meetingApi'
+import { getParticipantMissions } from '@/apis/missionApi'
 import QRPopup from '@/components/QRPopup'
 import useMeetingStore from '@/stores/useMeetingStore'
 import useUserStore from '@/stores/useUserStore'
+import { ApiError } from '@/types/api'
+import { MeetingPasswordResponse, ShareMeetingResponse } from '@/types/meeting'
+import { GetParticipantMissionsResponse } from '@/types/mission'
 import Edit from 'public/icons/edit.svg'
 import LinkIcon from 'public/icons/link.svg'
 import QRCode from 'public/icons/qr-code.svg'
@@ -19,24 +23,39 @@ function MeetingRaising() {
   )
   const meetingId =
     useMeetingStore((state) => state.meetingData?.meetingId) ?? 0
+
   const {
     data: shareData,
     isLoading: isShareDataLoading,
     error: shareDataError,
-  } = useShareMeeting(meetingId)
-  console.log(shareData)
+  } = useQuery<ShareMeetingResponse, ApiError>({
+    queryKey: ['meeting', meetingId, 'share'],
+    queryFn: () => shareMeeting(meetingId),
+    enabled: !!meetingId,
+    retry: false,
+  })
 
   const {
     data: missionData,
     isLoading: isMissionDataLoading,
     error: missionDataError,
-  } = useGetParticipantMissions(meetingId)
+  } = useQuery<GetParticipantMissionsResponse, ApiError>({
+    queryKey: ['missions', meetingId],
+    queryFn: () => getParticipantMissions(meetingId),
+    enabled: !!meetingId,
+    retry: false,
+  })
 
   const {
     data: passwordData,
     isLoading: isPasswordDataLoading,
     error: passwordDataError,
-  } = useGetMeetingPassword(meetingId)
+  } = useQuery<MeetingPasswordResponse, ApiError>({
+    queryKey: ['meeting', meetingId, 'password'],
+    queryFn: () => getMeetingPassword(meetingId),
+    enabled: !!meetingId,
+    retry: false,
+  })
 
   const [sharePassword, setSharePassword] = useState(false)
   const [shareAdminKey, setShareAdminKey] = useState(false)

--- a/src/hooks/useCheckMeetingLink.ts
+++ b/src/hooks/useCheckMeetingLink.ts
@@ -1,0 +1,30 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query'
+import { getMeetingByLink } from '@/apis/meetingApi'
+import { ApiError } from '@/types/api'
+import { CheckMeetResponse } from '@/types/meeting'
+
+type CheckMeetingLinkOptions = Omit<
+  UseQueryOptions<CheckMeetResponse, ApiError, CheckMeetResponse>,
+  'queryFn' | 'queryKey'
+> & {
+  queryKey?: string[]
+}
+
+function useCheckMeetingLink(
+  link: string,
+  options?: CheckMeetingLinkOptions,
+): UseQueryResult<CheckMeetResponse, ApiError> {
+  return useQuery<CheckMeetResponse, ApiError, CheckMeetResponse>({
+    queryKey: options?.queryKey ?? ['meeting', 'link', link],
+    queryFn: () => getMeetingByLink(link),
+    enabled: options?.enabled ?? !!link,
+    retry: options?.retry ?? false,
+    ...options,
+  })
+}
+
+export default useCheckMeetingLink

--- a/src/hooks/useParticipantsMe.ts
+++ b/src/hooks/useParticipantsMe.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import { getParticipantsMe } from '@/apis/participantsApi'
+import useUserStore from '@/stores/useUserStore'
+import { ApiError } from '@/types/api'
+import { GetParticipantsMeResponse } from '@/types/participants'
+
+const useParticipantsMe = (
+  meetingId: number,
+  hasTokens: boolean = true,
+  isEnabled: boolean = true,
+) => {
+  const { setParticipantId, setNickname, setRole, setShootCount } =
+    useUserStore()
+
+  return useQuery<GetParticipantsMeResponse, ApiError>({
+    queryKey: ['participants', meetingId, 'me'],
+    queryFn: async () => {
+      const response = await getParticipantsMe(meetingId)
+      const { participantId, nickname, role, shootCount } = response.data
+
+      setParticipantId(participantId)
+      setNickname(nickname)
+      setRole(role as 'LEADER' | 'PARTICIPANT')
+      setShootCount(shootCount)
+
+      return response
+    },
+    enabled: !!meetingId && isEnabled && hasTokens === true,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+}
+
+export default useParticipantsMe

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,13 @@
+export interface ApiResponse<T = null> {
+  status: number
+  data: T
+}
+
+export interface ApiError {
+  status: number
+  data: null
+  error: {
+    code: string
+    message: string
+  }
+}

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -1,0 +1,21 @@
+import { MeetingData } from '@/stores/useMeetingStore'
+import { ApiResponse } from '@/types/api'
+
+export type CheckNicknameResponse = ApiResponse<{
+  isAvailableNickname: boolean
+}>
+export type JoinMeetingResponse = ApiResponse<{ participantId: number }>
+export type CheckMeetResponse = ApiResponse<MeetingData>
+export type ValidatePasswordResponse = ApiResponse
+export type ValidateLeaderAuthKeyResponse = ApiResponse
+export type ShareMeetingResponse = ApiResponse<{ meetingLink: string }>
+export type MeetingPasswordResponse = ApiResponse<{
+  password: string
+  leaderAuthKey?: string
+}>
+export type ModifyMeetingResponse = ApiResponse<{
+  meetingId: number
+  name: string
+  description: string
+  symbolColor: string
+}>

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,0 +1,27 @@
+// types/mission.ts
+import { ApiResponse } from './api'
+
+export interface RandomMission {
+  randomMissionId: number
+  content: string
+}
+
+export interface Mission {
+  missionId: number
+  content: string
+}
+
+export interface LeaderMission extends Mission {
+  hasParticipants: boolean
+}
+
+export type GetRandomMissionsResponse = ApiResponse<RandomMission[]>
+export type GetCompletedMissionsResponse = ApiResponse<Mission[]>
+export type GetInCompleteMissionResponse = ApiResponse<Mission[]>
+export type GetParticipantMissionsResponse = ApiResponse<Mission[]>
+export type GetLeaderMissionResponse = ApiResponse<LeaderMission[]>
+export type DeleteMissionResponse = ApiResponse<string>
+export type CreateMissionResponse = ApiResponse<{
+  missionId: number
+  content: string
+}>

--- a/src/types/participants.ts
+++ b/src/types/participants.ts
@@ -1,0 +1,18 @@
+import { ApiResponse } from '@/types/api'
+
+export interface Participant {
+  participantId: number
+  role: string
+  nickname: string
+  shootCount: number
+}
+
+export interface ParticipantsResponse
+  extends ApiResponse<{
+    nextCursorId: number
+    data: Participant[]
+    count: number
+    hasNext: boolean
+  }> {}
+
+export type GetParticipantsMeResponse = ApiResponse<Participant>

--- a/src/types/snap.ts
+++ b/src/types/snap.ts
@@ -1,0 +1,21 @@
+import { ApiResponse } from './api'
+
+export type UploadSnapResponse = ApiResponse<{
+  snapId: number
+  snapUrl: string
+}>
+
+export type GetSnapDetailResponse = ApiResponse<{
+  snapId: number
+  snapUrl: string
+  shootDate: string
+  type: 'SIMPLE' | 'MEETING_MISSION' | 'RANDOM_MISSION'
+  photographer: {
+    participantId: number
+    nickname: string
+  }
+  mission?: {
+    missionId?: number
+    content?: string
+  }
+}>


### PR DESCRIPTION
## 변경사항
- axios를 이용한 API 호출 로직과 tanstack query를 이용한 데이터 관리 로직을 분리했습니다.

## 세부사항
- ~Api.ts 파일에 axios를 이용한 API 호출 로직을 작성하여 API 호출과 비동기 데이터 관리를 명확히 분리했습니다.
- tanstack query 로직은 API를 사용하는 각 컴포넌트에 작성하여 컴포넌트 단위의 데이터 관리가 가능하게 했습니다.
- 재사용 가능한 tanstack query 로직은 별도의 hook으로 구현하여 여러 컴포넌트에서 쉽게 사용할 수 있도록 구성했습니다.